### PR TITLE
managing zsh with home-manager

### DIFF
--- a/roles/defaults.nix
+++ b/roles/defaults.nix
@@ -67,8 +67,12 @@
       _HIHideMenuBar = true; # autohide top panel
     };
   };
-   # Add flake support 
+
+  # Add flake support 
   nix.extraOptions = ''
     experimental-features = nix-command flakes
   '';
+
+  # Use touch ID for sudo auth
+  security.pam.enableSudoTouchIdAuth = true;   
 }

--- a/roles/home-manager/user.nix
+++ b/roles/home-manager/user.nix
@@ -2,6 +2,32 @@
 
 {
   home.stateVersion = "23.05";
+  # Zsh stuff
+  programs.zsh = {
+    enable = true;
+    enableCompletion = true;
+    enableAutosuggestions = true;
+    enableSyntaxHighlighting = true;
+
+    # Enable oh-my-zsh
+    oh-my-zsh = {
+      enable = true;
+      plugins = [
+        "aliases"
+        "battery"
+        "brew"
+        "docker"
+        "git"
+        "iterm2"
+        "macos"
+        "nmap"
+        "sudo"
+      ];
+      theme = "apple";
+    };
+  };
+
+  # Firefox stuff
   programs.firefox = {
     enable = true;
     # Handled by the Homebrew module


### PR DESCRIPTION
Two changes:

Managing zsh/oh-my-zsh with home-manager
Allow `sudo` with touchId