### PR TITLE
updated github action for install-nix-action to latest version

### DIFF
--- a/.github/workflows/darwin.yml
+++ b/.github/workflows/darwin.yml
@@ -22,7 +22,7 @@ jobs:
       uses: actions/checkout@v2
   
     - name: Install Nix
-      uses: cachix/install-nix-action@v18
+      uses: cachix/install-nix-action@v22
 
     - name: Build macos-desktop output 
       run: |


### PR DESCRIPTION
Addresses build issues with SIP on MacOS: https://github.com/cachix/install-nix-action/issues/183